### PR TITLE
Add graphs showing consumption and production on animation view

### DIFF
--- a/packages/client/src/modules/charts/LineEvolution.tsx
+++ b/packages/client/src/modules/charts/LineEvolution.tsx
@@ -1,4 +1,4 @@
-import { Card, useTheme } from "@mui/material";
+import { Card } from "@mui/material";
 import {
   LineChart,
   Line,
@@ -13,7 +13,6 @@ import {
 export { LineEvolution };
 
 function LineEvolution({ data }: { data: any[] }) {
-  const theme = useTheme();
   return (
     <Card
       sx={{

--- a/packages/client/src/modules/charts/LineEvolution.tsx
+++ b/packages/client/src/modules/charts/LineEvolution.tsx
@@ -1,0 +1,43 @@
+import { Card, useTheme } from "@mui/material";
+import {
+  LineChart,
+  Line,
+  CartesianGrid,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+
+export { LineEvolution };
+
+function LineEvolution({ data }: { data: any[] }) {
+  const theme = useTheme();
+  return (
+    <Card
+      sx={{
+        alignItems: "center",
+        display: "flex",
+        justifyContent: "center",
+        p: 2,
+      }}
+    >
+      <ResponsiveContainer width="100%" aspect={4.0 / 3.0}>
+        <LineChart data={data}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="name" />
+          <YAxis name="kWh/j" domain={[0, 1500]} />
+          <Tooltip />
+          <Legend />
+          <Line dataKey="team1" stroke="blue" name="Equipe 1" unit="kWh" />
+          <Line dataKey="team2" stroke="orange" name="Equipe 2" unit="kWh" />
+          <Line dataKey="team3" stroke="green" name="Equipe 3" unit="kWh" />
+          <Line dataKey="team4" stroke="red" name="Equipe 4" unit="kWh" />
+          <Line dataKey="team5" stroke="purple" name="Equipe 5" unit="kWh" />
+          <Line dataKey="team6" stroke="brown" name="Equipe 6" unit="kWh" />
+        </LineChart>
+      </ResponsiveContainer>
+    </Card>
+  );
+}

--- a/packages/client/src/modules/charts/index.ts
+++ b/packages/client/src/modules/charts/index.ts
@@ -1,3 +1,4 @@
 import { StackedEnergyBars } from "./StackedEnergyBars";
+import { LineEvolution } from "./LineEvolution";
 
-export { StackedEnergyBars };
+export { StackedEnergyBars, LineEvolution };

--- a/packages/client/src/modules/play/GameConsole/GameConsole.tsx
+++ b/packages/client/src/modules/play/GameConsole/GameConsole.tsx
@@ -44,11 +44,11 @@ function MeanStatsConsole() {
   const { game } = usePlay();
   return (
     <Box>
-      <Grid container justifyContent="space-evenly">
-        <Grid item sx={{ m: 1 }} xs={11} sm={5}>
+      <Grid container justifyContent="space-between">
+        <Grid item xs={11} sm={5.75}>
           <ConsumptionStats />
         </Grid>
-        <Grid item sx={{ m: 1 }} xs={11} sm={5}>
+        <Grid item xs={11} sm={5.75}>
           <ProductionStats />
         </Grid>
       </Grid>
@@ -61,7 +61,10 @@ function MeanStatsConsole() {
             </Typography>
             {game.teams.map((team) => {
               return (
-                <Typography sx={{ textAlign: "center", fontSize: "0.7em" }}>
+                <Typography
+                  key={team.id}
+                  sx={{ textAlign: "center", fontSize: "0.7em" }}
+                >
                   {" "}
                   <GroupsIcon /> {`${team.name}:  250pts`}{" "}
                 </Typography>
@@ -77,7 +80,10 @@ function MeanStatsConsole() {
             </Typography>
             {game.teams.map((team) => {
               return (
-                <Typography sx={{ textAlign: "center", fontSize: "0.7em" }}>
+                <Typography
+                  key={team.id}
+                  sx={{ textAlign: "center", fontSize: "0.7em" }}
+                >
                   {" "}
                   <GroupsIcon /> {`${team.name}:  250T/an`}{" "}
                 </Typography>
@@ -93,7 +99,10 @@ function MeanStatsConsole() {
             </Typography>
             {game.teams.map((team) => {
               return (
-                <Typography sx={{ textAlign: "center", fontSize: "0.7em" }}>
+                <Typography
+                  key={team.id}
+                  sx={{ textAlign: "center", fontSize: "0.7em" }}
+                >
                   {" "}
                   <GroupsIcon /> {`${team.name}:  250€/J`}{" "}
                 </Typography>

--- a/packages/client/src/modules/play/GameConsole/GameConsole.tsx
+++ b/packages/client/src/modules/play/GameConsole/GameConsole.tsx
@@ -1,13 +1,20 @@
-import { Box, Grid, Tooltip, Typography, useTheme } from "@mui/material";
-import PersonIcon from "@mui/icons-material/Person";
-import { ITeamWithPlayers } from "../../../utils/types";
+import { Box, Button, Grid, Typography, useTheme } from "@mui/material";
 import GameStepper from "../../common/components/Stepper";
+import BarChartRoundedIcon from "@mui/icons-material/BarChartRounded";
+import GroupIcon from "@mui/icons-material/Group";
+import ArrowForwardIcon from "@mui/icons-material/ArrowForward";
+
+import EmojiEventsIcon from "@mui/icons-material/EmojiEvents";
+import GroupsIcon from "@mui/icons-material/Groups";
+import WaterRoundedIcon from "@mui/icons-material/WaterRounded";
+import PaidRoundedIcon from "@mui/icons-material/PaidRounded";
+
 import { PlayBox } from "../Components";
 import { usePlay } from "../context/playContext";
 import { PlayLayout } from "../PlayLayout";
 import { useState } from "react";
-import { PlayerList } from "./PlayerList";
-import { PlayerChart } from "./PlayerChart";
+import { Teams, TeamDetails } from "./Teams";
+import { ConsumptionStats, ProductionStats } from "./ProdStats";
 
 export { GameConsole };
 
@@ -22,101 +29,131 @@ function GameConsole() {
 function GameAdminContent() {
   const { game } = usePlay();
   const firstTeamId = game.teams[0].id;
+  const [selectedScreen, setSelectedScreen] = useState<string>("Mean Stats");
   const [selectedTeamId, setSelectedTeamId] = useState<number>(firstTeamId);
   const selectedTeam = game.teams.find(({ id }) => id === selectedTeamId);
-  if (!selectedTeam) return <></>;
+  if (selectedScreen === "Teams" && !selectedTeam) return <></>;
   return (
     <>
-      <Header />
-      <Teams
-        selectedTeamId={selectedTeamId}
-        setSelectedTeamId={setSelectedTeamId}
+      <Header
+        selectedScreen={selectedScreen}
+        setSelectedScreen={setSelectedScreen}
       />
-      <TeamDetails team={selectedTeam} />
+      {selectedScreen === "Teams" && selectedTeam && (
+        <Box>
+          <Teams
+            selectedTeamId={selectedTeamId}
+            setSelectedTeamId={setSelectedTeamId}
+          />
+          <TeamDetails team={selectedTeam} />
+        </Box>
+      )}
+      {selectedScreen === "Mean Stats" && (
+        <Box>
+          <Grid container justifyContent="space-evenly">
+            <Grid item sx={{ m: 1 }} xs={11} sm={5}>
+              <ConsumptionStats />
+            </Grid>
+            <Grid item sx={{ m: 1 }} xs={11} sm={5}>
+              <ProductionStats />
+            </Grid>
+          </Grid>
+          <Grid container justifyContent="center">
+            <Grid item sx={{ m: 1 }} xs={4} sm={3}>
+              <PlayBox sx={{ m: 2, p: 1 }}>
+                <Typography sx={{ color: "#F9C74F", textAlign: "center" }}>
+                  {" "}
+                  Points <EmojiEventsIcon />{" "}
+                </Typography>
+                {game.teams.map((team) => {
+                  return (
+                    <Typography sx={{ textAlign: "center", fontSize: "0.7em" }}>
+                      {" "}
+                      <GroupsIcon /> {`${team.name}:  250pts`}{" "}
+                    </Typography>
+                  );
+                })}
+              </PlayBox>
+            </Grid>
+            <Grid item sx={{ m: 1 }} xs={4} sm={3}>
+              <PlayBox sx={{ m: 2, p: 1 }}>
+                <Typography sx={{ textAlign: "center" }}>
+                  {" "}
+                  CO2 (T/an) <WaterRoundedIcon />{" "}
+                </Typography>
+                {game.teams.map((team) => {
+                  return (
+                    <Typography sx={{ textAlign: "center", fontSize: "0.7em" }}>
+                      {" "}
+                      <GroupsIcon /> {`${team.name}:  250T/an`}{" "}
+                    </Typography>
+                  );
+                })}
+              </PlayBox>
+            </Grid>
+            <Grid item sx={{ m: 1 }} xs={4} sm={3}>
+              <PlayBox sx={{ m: 2, p: 1 }}>
+                <Typography sx={{ textAlign: "center" }}>
+                  {" "}
+                  Budget (€/J) <PaidRoundedIcon />{" "}
+                </Typography>
+                {game.teams.map((team) => {
+                  return (
+                    <Typography sx={{ textAlign: "center", fontSize: "0.7em" }}>
+                      {" "}
+                      <GroupsIcon /> {`${team.name}:  250€/J`}{" "}
+                    </Typography>
+                  );
+                })}
+              </PlayBox>
+            </Grid>
+          </Grid>
+        </Box>
+      )}
     </>
   );
 }
 
-function TeamDetails({ team }: { team: ITeamWithPlayers }) {
-  return (
-    <PlayBox mt={2}>
-      <Typography
-        display="flex"
-        justifyContent="center"
-        variant="h5"
-      >{`Détails ${team.name}`}</Typography>
-      <Grid container>
-        <Grid item xs={6}>
-          <PlayerList team={team} />
-        </Grid>
-        <Grid item xs={6}>
-          <PlayerChart team={team} />
-        </Grid>
-      </Grid>
-    </PlayBox>
-  );
-}
-
-function Header() {
+function Header(props: any) {
+  const { selectedScreen, setSelectedScreen } = props;
   const { game } = usePlay();
+  const theme = useTheme();
+
   return (
     <PlayBox>
       <Grid container>
-        <Grid item xs={3} />
+        <Grid item xs={3}>
+          <Button
+            variant="contained"
+            color={selectedScreen === "Mean Stats" ? "secondary" : "primary"}
+            sx={{ border: `1px solid ${theme.palette.secondary.main}` }}
+            onClick={() => setSelectedScreen("Mean Stats")}
+          >
+            <BarChartRoundedIcon sx={{ mr: 1 }} /> Statistiques
+          </Button>
+          <Button
+            sx={{ mt: 1, border: `1px solid ${theme.palette.secondary.main}` }}
+            variant="contained"
+            color={selectedScreen === "Teams" ? "secondary" : "primary"}
+            onClick={() => setSelectedScreen("Teams")}
+          >
+            <GroupIcon sx={{ mr: 1 }} /> Equipes
+          </Button>
+        </Grid>
         <Grid item xs={6}>
           <GameStepper step={game.step} typographyProps={{ variant: "h5" }} />
         </Grid>
-        <Grid item xs={3} />
+        <Grid item sx={{ margin: "auto" }} xs={3}>
+          <Button
+            variant="contained"
+            color={selectedScreen === "Mean Stats" ? "secondary" : "primary"}
+            sx={{ border: `1px solid ${theme.palette.secondary.main}` }}
+            onClick={() => console.log("next step - wip")}
+          >
+            Passer à l'étape suivante <ArrowForwardIcon />
+          </Button>
+        </Grid>
       </Grid>
     </PlayBox>
-  );
-}
-
-function Teams({
-  selectedTeamId,
-  setSelectedTeamId,
-}: {
-  selectedTeamId: number;
-  setSelectedTeamId: React.Dispatch<React.SetStateAction<number>>;
-}) {
-  const { game } = usePlay();
-  const theme = useTheme();
-  return (
-    <Grid container justifyContent="space-between" mt={2}>
-      {game.teams.map((team) => {
-        const color =
-          team.id === selectedTeamId ? theme.palette.secondary.main : "white";
-        return (
-          <Grid
-            key={team.id}
-            item
-            onClick={() => setSelectedTeamId(team.id)}
-            sx={{ cursor: "pointer" }}
-            xs={2}
-          >
-            <PlayBox borderColor={color} color={color}>
-              <Typography textAlign="center" variant="h5">
-                {team.name}
-              </Typography>
-              <Players teamWithPlayers={team} />
-            </PlayBox>
-          </Grid>
-        );
-      })}
-    </Grid>
-  );
-}
-
-function Players({ teamWithPlayers }: { teamWithPlayers: ITeamWithPlayers }) {
-  return (
-    <Box display="flex" minHeight="24px">
-      {teamWithPlayers.players.map(({ user }) => {
-        return (
-          <Tooltip key={user.id} title={`${user.firstName} ${user.lastName}`}>
-            <PersonIcon />
-          </Tooltip>
-        );
-      })}
-    </Box>
   );
 }

--- a/packages/client/src/modules/play/GameConsole/GameConsole.tsx
+++ b/packages/client/src/modules/play/GameConsole/GameConsole.tsx
@@ -21,96 +21,106 @@ export { GameConsole };
 function GameConsole() {
   return (
     <PlayLayout title="Console">
-      <GameAdminContent />
+      <GameConsoleContent />
     </PlayLayout>
   );
 }
 
-function GameAdminContent() {
-  const { game } = usePlay();
-  const firstTeamId = game.teams[0].id;
+function GameConsoleContent() {
   const [selectedScreen, setSelectedScreen] = useState<string>("Mean Stats");
-  const [selectedTeamId, setSelectedTeamId] = useState<number>(firstTeamId);
-  const selectedTeam = game.teams.find(({ id }) => id === selectedTeamId);
-  if (selectedScreen === "Teams" && !selectedTeam) return <></>;
   return (
     <>
       <Header
         selectedScreen={selectedScreen}
         setSelectedScreen={setSelectedScreen}
       />
-      {selectedScreen === "Teams" && selectedTeam && (
-        <Box>
-          <Teams
-            selectedTeamId={selectedTeamId}
-            setSelectedTeamId={setSelectedTeamId}
-          />
-          <TeamDetails team={selectedTeam} />
-        </Box>
-      )}
-      {selectedScreen === "Mean Stats" && (
-        <Box>
-          <Grid container justifyContent="space-evenly">
-            <Grid item sx={{ m: 1 }} xs={11} sm={5}>
-              <ConsumptionStats />
-            </Grid>
-            <Grid item sx={{ m: 1 }} xs={11} sm={5}>
-              <ProductionStats />
-            </Grid>
-          </Grid>
-          <Grid container justifyContent="center">
-            <Grid item sx={{ m: 1 }} xs={4} sm={3}>
-              <PlayBox sx={{ m: 2, p: 1 }}>
-                <Typography sx={{ color: "#F9C74F", textAlign: "center" }}>
-                  {" "}
-                  Points <EmojiEventsIcon />{" "}
-                </Typography>
-                {game.teams.map((team) => {
-                  return (
-                    <Typography sx={{ textAlign: "center", fontSize: "0.7em" }}>
-                      {" "}
-                      <GroupsIcon /> {`${team.name}:  250pts`}{" "}
-                    </Typography>
-                  );
-                })}
-              </PlayBox>
-            </Grid>
-            <Grid item sx={{ m: 1 }} xs={4} sm={3}>
-              <PlayBox sx={{ m: 2, p: 1 }}>
-                <Typography sx={{ textAlign: "center" }}>
-                  {" "}
-                  CO2 (T/an) <WaterRoundedIcon />{" "}
-                </Typography>
-                {game.teams.map((team) => {
-                  return (
-                    <Typography sx={{ textAlign: "center", fontSize: "0.7em" }}>
-                      {" "}
-                      <GroupsIcon /> {`${team.name}:  250T/an`}{" "}
-                    </Typography>
-                  );
-                })}
-              </PlayBox>
-            </Grid>
-            <Grid item sx={{ m: 1 }} xs={4} sm={3}>
-              <PlayBox sx={{ m: 2, p: 1 }}>
-                <Typography sx={{ textAlign: "center" }}>
-                  {" "}
-                  Budget (€/J) <PaidRoundedIcon />{" "}
-                </Typography>
-                {game.teams.map((team) => {
-                  return (
-                    <Typography sx={{ textAlign: "center", fontSize: "0.7em" }}>
-                      {" "}
-                      <GroupsIcon /> {`${team.name}:  250€/J`}{" "}
-                    </Typography>
-                  );
-                })}
-              </PlayBox>
-            </Grid>
-          </Grid>
-        </Box>
-      )}
+      {selectedScreen === "Teams" ? <TeamsConsole /> : null}
+      {selectedScreen === "Mean Stats" ? <MeanStatsConsole /> : null}
     </>
+  );
+}
+
+function MeanStatsConsole() {
+  const { game } = usePlay();
+  return (
+    <Box>
+      <Grid container justifyContent="space-evenly">
+        <Grid item sx={{ m: 1 }} xs={11} sm={5}>
+          <ConsumptionStats />
+        </Grid>
+        <Grid item sx={{ m: 1 }} xs={11} sm={5}>
+          <ProductionStats />
+        </Grid>
+      </Grid>
+      <Grid container justifyContent="center">
+        <Grid item sx={{ m: 1 }} xs={4} sm={3}>
+          <PlayBox sx={{ m: 2, p: 1 }}>
+            <Typography sx={{ color: "#F9C74F", textAlign: "center" }}>
+              {" "}
+              Points <EmojiEventsIcon />{" "}
+            </Typography>
+            {game.teams.map((team) => {
+              return (
+                <Typography sx={{ textAlign: "center", fontSize: "0.7em" }}>
+                  {" "}
+                  <GroupsIcon /> {`${team.name}:  250pts`}{" "}
+                </Typography>
+              );
+            })}
+          </PlayBox>
+        </Grid>
+        <Grid item sx={{ m: 1 }} xs={4} sm={3}>
+          <PlayBox sx={{ m: 2, p: 1 }}>
+            <Typography sx={{ textAlign: "center" }}>
+              {" "}
+              CO2 (T/an) <WaterRoundedIcon />{" "}
+            </Typography>
+            {game.teams.map((team) => {
+              return (
+                <Typography sx={{ textAlign: "center", fontSize: "0.7em" }}>
+                  {" "}
+                  <GroupsIcon /> {`${team.name}:  250T/an`}{" "}
+                </Typography>
+              );
+            })}
+          </PlayBox>
+        </Grid>
+        <Grid item sx={{ m: 1 }} xs={4} sm={3}>
+          <PlayBox sx={{ m: 2, p: 1 }}>
+            <Typography sx={{ textAlign: "center" }}>
+              {" "}
+              Budget (€/J) <PaidRoundedIcon />{" "}
+            </Typography>
+            {game.teams.map((team) => {
+              return (
+                <Typography sx={{ textAlign: "center", fontSize: "0.7em" }}>
+                  {" "}
+                  <GroupsIcon /> {`${team.name}:  250€/J`}{" "}
+                </Typography>
+              );
+            })}
+          </PlayBox>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+}
+
+function TeamsConsole() {
+  const { game } = usePlay();
+  const firstTeamId = game.teams[0].id;
+  const [selectedTeamId, setSelectedTeamId] = useState<number>(firstTeamId);
+  const selectedTeam = game.teams.find(({ id }) => id === selectedTeamId);
+  if (!selectedTeam) return <></>;
+
+  return (
+    <Box>
+      <Teams
+        selectedTeamId={selectedTeamId}
+        setSelectedTeamId={setSelectedTeamId}
+      />
+      <TeamDetails team={selectedTeam} />
+    </Box>
   );
 }
 
@@ -146,7 +156,7 @@ function Header(props: any) {
         <Grid item sx={{ margin: "auto" }} xs={3}>
           <Button
             variant="contained"
-            color={selectedScreen === "Mean Stats" ? "secondary" : "primary"}
+            color={"secondary"}
             sx={{ border: `1px solid ${theme.palette.secondary.main}` }}
             onClick={() => console.log("next step - wip")}
           >

--- a/packages/client/src/modules/play/GameConsole/PlayerList.tsx
+++ b/packages/client/src/modules/play/GameConsole/PlayerList.tsx
@@ -16,7 +16,7 @@ function PlayerList({ team }: { team: ITeamWithPlayers }) {
             <Typography variant="h5">{buildName(player.user)}</Typography>
             <Box display="flex" alignItems="center" mt={2}>
               <PaidIcon />
-              <Typography ml={1}>Budget restant: 15h/j</Typography>
+              <Typography ml={1}>Budget restant: 15€/j</Typography>
             </Box>
             <Box display="flex" alignItems="center">
               <CloudIcon />

--- a/packages/client/src/modules/play/GameConsole/ProdStats.tsx
+++ b/packages/client/src/modules/play/GameConsole/ProdStats.tsx
@@ -1,0 +1,115 @@
+import { Typography, Grid, Box } from "@mui/material";
+import { LineEvolution } from "../../charts";
+import { PlayBox } from "../Components";
+import FactoryRoundedIcon from "@mui/icons-material/FactoryRounded";
+import ShoppingCartRoundedIcon from "@mui/icons-material/ShoppingCartRounded";
+
+export { ConsumptionStats, ProductionStats };
+
+function ConsumptionStats() {
+  return (
+    <PlayBox mt={2}>
+      <Grid container>
+        <Grid item xs={12}>
+          <Typography
+            display="flex"
+            variant="h5"
+            sx={{ textAlign: "center", fontSize: "1em" }}
+          >
+            {" "}
+            <ShoppingCartRoundedIcon sx={{ height: "auto", mr: 2 }} />{" "}
+            Comparaison de l'évolution des consommations entre équipes
+          </Typography>
+        </Grid>
+        <Grid item xs={12}>
+          <Box p={2}>
+            <LineEvolution data={buildDataCons()} />
+          </Box>
+        </Grid>
+      </Grid>
+    </PlayBox>
+  );
+}
+
+function ProductionStats() {
+  return (
+    <PlayBox mt={2}>
+      <Grid container>
+        <Grid item xs={12}>
+          <Typography
+            display="flex"
+            variant="h5"
+            sx={{ textAlign: "center", fontSize: "1em" }}
+          >
+            {" "}
+            <FactoryRoundedIcon sx={{ height: "auto", mr: 2 }} /> Comparaison de
+            l'évolution des productions entre équipes{" "}
+          </Typography>
+        </Grid>
+        <Grid item xs={12}>
+          <Box p={2}>
+            <LineEvolution data={buildDataProd()} />
+          </Box>
+        </Grid>
+      </Grid>
+    </PlayBox>
+  );
+}
+
+function buildDataCons() {
+  return [
+    {
+      name: "Situation initiale",
+      team1: "1300",
+      team2: "1270",
+      team3: "1250",
+    },
+    {
+      name: "Etape 1",
+      team1: "1200",
+      team2: "1150",
+      team3: "1120",
+    },
+    {
+      name: "Etape 2",
+      team1: "1100",
+      team2: "1098",
+      team3: "1087",
+    },
+    {
+      name: "Etape 3",
+    },
+    {
+      name: "Etape 4",
+    },
+  ];
+}
+
+function buildDataProd() {
+  return [
+    {
+      name: "Situation initiale",
+      team1: "0",
+      team2: "0",
+      team3: "0",
+    },
+    {
+      name: "Etape 1",
+      team1: "200",
+      team2: "300",
+      team3: "321",
+    },
+    {
+      name: "Etape 2",
+      team1: "590",
+      team2: "321",
+      team3: "459",
+    },
+    {
+      name: "Etape 3",
+    },
+    {
+      name: "Etape 4",
+    },
+  ];
+}

--- a/packages/client/src/modules/play/GameConsole/Teams.tsx
+++ b/packages/client/src/modules/play/GameConsole/Teams.tsx
@@ -1,0 +1,78 @@
+import { Box, Grid, Tooltip, Typography, useTheme } from "@mui/material";
+import PersonIcon from "@mui/icons-material/Person";
+import { ITeamWithPlayers } from "../../../utils/types";
+import { PlayerList } from "./PlayerList";
+import { PlayerChart } from "./PlayerChart";
+import { PlayBox } from "../Components";
+import { usePlay } from "../context/playContext";
+
+export { TeamDetails, Teams };
+
+function TeamDetails({ team }: { team: ITeamWithPlayers }) {
+  return (
+    <PlayBox mt={2}>
+      <Typography
+        display="flex"
+        justifyContent="center"
+        variant="h5"
+      >{`Détails ${team.name}`}</Typography>
+      <Grid container>
+        <Grid item xs={6}>
+          <PlayerList team={team} />
+        </Grid>
+        <Grid item xs={6}>
+          <PlayerChart team={team} />
+        </Grid>
+      </Grid>
+    </PlayBox>
+  );
+}
+
+function Teams({
+  selectedTeamId,
+  setSelectedTeamId,
+}: {
+  selectedTeamId: number;
+  setSelectedTeamId: React.Dispatch<React.SetStateAction<number>>;
+}) {
+  const { game } = usePlay();
+  const theme = useTheme();
+  return (
+    <Grid container justifyContent="space-between" mt={2}>
+      {game.teams.map((team) => {
+        const color =
+          team.id === selectedTeamId ? theme.palette.secondary.main : "white";
+        return (
+          <Grid
+            key={team.id}
+            item
+            onClick={() => setSelectedTeamId(team.id)}
+            sx={{ cursor: "pointer" }}
+            xs={2}
+          >
+            <PlayBox borderColor={color} color={color}>
+              <Typography textAlign="center" variant="h5">
+                {team.name}
+              </Typography>
+              <Players teamWithPlayers={team} />
+            </PlayBox>
+          </Grid>
+        );
+      })}
+    </Grid>
+  );
+}
+
+function Players({ teamWithPlayers }: { teamWithPlayers: ITeamWithPlayers }) {
+  return (
+    <Box display="flex" minHeight="24px">
+      {teamWithPlayers.players.map(({ user }) => {
+        return (
+          <Tooltip key={user.id} title={`${user.firstName} ${user.lastName}`}>
+            <PersonIcon />
+          </Tooltip>
+        );
+      })}
+    </Box>
+  );
+}


### PR DESCRIPTION
Pour l'instant que des données en dur pour les valeurs, et 6 lignes en permanence pour les équipes, il faudrait voir comment gérer la génération de couleurs pour les lignes du graphique 

et est-ce qu'il y a quelque chose que empêchent les joueurs d'aller sur la page de gestions équipes / stats pour l'instant ? 