### PR TITLE
chore(ogre-server): Log errors to sentry

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -4,6 +4,8 @@
   "dependencies": {
     "@prisma/client": "^3.12.0",
     "@sendgrid/mail": "^7.6.2",
+    "@sentry/node": "^7.43.0",
+    "@sentry/tracing": "^7.43.0",
     "body-parser": "^1.20.0",
     "cookie": "^0.5.0",
     "cookie-parser": "^1.4.6",

--- a/packages/server/src/error-handling/index.ts
+++ b/packages/server/src/error-handling/index.ts
@@ -1,0 +1,1 @@
+export * from "./utils";

--- a/packages/server/src/error-handling/utils.ts
+++ b/packages/server/src/error-handling/utils.ts
@@ -1,0 +1,35 @@
+import * as Sentry from "@sentry/node";
+import * as Tracing from "@sentry/tracing";
+import { Request, Response, Router } from "express";
+import { getUserRequesting } from "../lib/express";
+
+export { initErrorTracer, traceError, traceRequests };
+
+const initErrorTracer = (app: Router) => {
+  Sentry.init({
+    dsn: process.env.SENTRY_DSN,
+    environment: process.env.SENTRY_ENV || "development",
+    integrations: [
+      new Sentry.Integrations.Http({ tracing: true }),
+      new Tracing.Integrations.Express({ app }),
+    ],
+    // TODO: adapt value in production.
+    tracesSampleRate: 1.0,
+  });
+};
+
+const traceRequests = (app: Router) => {
+  app.use(Sentry.Handlers.requestHandler());
+  app.use(Sentry.Handlers.tracingHandler());
+};
+
+const traceError = (err: Error, req: Request, res: Response) => {
+  const data = Sentry.extractRequestData(req);
+  const user = getUserRequesting(res);
+  Sentry.captureException(err, {
+    user: {
+      id: user?.id?.toString(),
+    },
+    contexts: data,
+  });
+};

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -11,11 +11,14 @@ import { initWebSocket } from "./modules/websocket";
 import { logger } from "./logger";
 import { logError, setRequestId } from "./middlewares";
 import { limiter } from "./middlewares/limit";
+import { initErrorTracer, traceRequests } from "./error-handling";
 
 const app = express();
+initErrorTracer(app);
 
 connectToDatase().then(seed);
 
+traceRequests(app);
 app.use(bodyParser.urlencoded({ extended: false }));
 // Parse JSON bodies (as sent by API clients)
 app.use(bodyParser.json());

--- a/packages/server/src/middlewares/logError.ts
+++ b/packages/server/src/middlewares/logError.ts
@@ -1,4 +1,5 @@
 import { NextFunction, Request, Response } from "express";
+import { traceError } from "../error-handling";
 import { logger } from "../logger";
 import {
   BusinessError,
@@ -11,12 +12,13 @@ const isProd = process.env.NODE_ENV === "production";
 
 const logError = (
   err: Error,
-  _: Request,
+  req: Request,
   res: Response,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   next: NextFunction
 ) => {
   logger.error(err);
+  traceError(err, req, res);
 
   if (err instanceof BusinessError) {
     if (err.code === "USER_NOT_AUTHENTICATED") {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1724,7 +1724,7 @@
     "@sentry/utils" "7.43.0"
     tslib "^1.9.3"
 
-"@sentry/node@^7.19.0":
+"@sentry/node@^7.19.0", "@sentry/node@^7.43.0":
   version "7.43.0"
   resolved "https://registry.yarnpkg.com/@sentry/node/-/node-7.43.0.tgz#bcb553486ffe3f1413063e9125fd34f9d84277d2"
   integrity sha512-oXaTBq6Bk8Qwsd46hhRU2MLEnjYqWI41nPJmXyAWkDSYQTP7sUe1qM8bCUdsRpPwQh955Vq9qCRfgMbN4lEoAQ==


### PR DESCRIPTION
### Changes

L'avantage de tracker les erreurs sur sentry en plus des logs est qu'aujourd'hui on est limité sur la quantité de logs. Les erreurs qui datent de quelques jours n'apparaissent plus ce qui rend le debuggage compliqué.

Les variables d'environnement `SENTRY_DSN` et `SENTRY_ENV` ont été ajoutées en staging et en prod.

---

- ticket : https://ogre-d4g.atlassian.net/browse/D4G-259

### Remarks

![image](https://user-images.githubusercontent.com/15690915/226136841-6f6e0f32-0d6c-4c6e-9749-3a98b8d5cb66.png)

![image](https://user-images.githubusercontent.com/15690915/226136908-3d6248fe-7b80-4b23-842f-387c8680bcf6.png)
